### PR TITLE
Return record instead of zone object from Client->loadRecord

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -70,8 +70,7 @@ class Client
             $zone = substr($domain, strpos($domain, '.') + 1);
         }
         $zoneH = new Zone($this->config, $zone);
-        $zoneH->loadRecord($domain, $type);
-        return $zoneH;
+        return $zoneH->loadRecord($domain, $type);
     }
 
 }


### PR DESCRIPTION
The initial implementation erroneously returned the zone object instead of the record from the high-level Client->loadRecord() interface.